### PR TITLE
Fix defining tableviews in jade templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .monitor
 tmp.html
+.DS_Store
+dist-*

--- a/dist/kranium-jade.js
+++ b/dist/kranium-jade.js
@@ -145,6 +145,7 @@ valueAttrByTagName = {
 	label: 'text',
 	textfield: 'value',
 	button: 'title',
+	row: 'title',
 	def: 'text'
 };
 function getValueAttr(tagName){
@@ -320,7 +321,7 @@ Compiler.prototype = {
 
 	var hasChildren = tag.block && tag.block.nodes && tag.block.nodes.length;
 	if(hasChildren){
-		this.buf.push(', children: (function(){ var __els = []; ');
+		this.buf.push(', ' + (name == 'tableview' ? 'data' : 'children')  + ': (function(){ var __els = []; ');
 	}
 
     this.visit(tag.block, tag);
@@ -431,14 +432,8 @@ Compiler.prototype = {
     } else {*/
 	//console.log('codely: ' + tagName, code);
 	
-	valueAttrByTagName = {
-		label: 'text',
-		textfield: 'value',
-		button: 'title',
-		def: 'text'
-	};
 	if(tagName){
-		this.buf.push(", " + (valueAttrByTagName[tagName]||valueAttrByTagName.def) + ": (" + code.val.trim() + ")");
+		this.buf.push(", " + getValueAttr(tagName) + ": (" + code.val.trim() + ")");
 	} else {
 		this.buf.push(code.val);
 	}

--- a/dist/kranium-jade.js
+++ b/dist/kranium-jade.js
@@ -2193,7 +2193,7 @@ require.register("utils.js", function(module, exports, require){
  */
 
 var interpolate = exports.interpolate = function(str){
-  return str.replace(/(\\)?([#!]){(.*?)}/g, function(str, escape, flag, code){
+  return str.replace(/(\\)?([#!])\{(.*?)\}/g, function(str, escape, flag, code){
     return escape
       ? str
       : "' + "

--- a/lib/kranium-src/jade.js
+++ b/lib/kranium-src/jade.js
@@ -145,6 +145,7 @@ valueAttrByTagName = {
 	label: 'text',
 	textfield: 'value',
 	button: 'title',
+	row: 'title',
 	def: 'text'
 };
 function getValueAttr(tagName){
@@ -320,7 +321,7 @@ Compiler.prototype = {
 
 	var hasChildren = tag.block && tag.block.nodes && tag.block.nodes.length;
 	if(hasChildren){
-		this.buf.push(', children: (function(){ var __els = []; ');
+		this.buf.push(', ' + (name == 'tableview' ? 'data' : 'children')  + ': (function(){ var __els = []; ');
 	}
 
     this.visit(tag.block, tag);
@@ -431,14 +432,8 @@ Compiler.prototype = {
     } else {*/
 	//console.log('codely: ' + tagName, code);
 	
-	valueAttrByTagName = {
-		label: 'text',
-		textfield: 'value',
-		button: 'title',
-		def: 'text'
-	};
 	if(tagName){
-		this.buf.push(", " + (valueAttrByTagName[tagName]||valueAttrByTagName.def) + ": (" + code.val.trim() + ")");
+		this.buf.push(", " + getValueAttr(tagName) + ": (" + code.val.trim() + ")");
 	} else {
 		this.buf.push(code.val);
 	}

--- a/lib/kranium-src/jade.js
+++ b/lib/kranium-src/jade.js
@@ -2193,7 +2193,7 @@ require.register("utils.js", function(module, exports, require){
  */
 
 var interpolate = exports.interpolate = function(str){
-  return str.replace(/(\\)?([#!]){(.*?)}/g, function(str, escape, flag, code){
+  return str.replace(/(\\)?([#!])\{(.*?)\}/g, function(str, escape, flag, code){
     return escape
       ? str
       : "' + "


### PR DESCRIPTION
For example:

``` jade
tableview
    - each msg, user in users
        row= user + ' says ' + msg
    row
        button Hello
```

Would have written a test for this, but doesn't seem like you have a formal test suite set up (i just tested by dropping the above into kranium-demo test.jade )

Also, escaped the {}'s in the jade interpolation regex, since it was returning errors when running through Syntastic

Lastly, made minor changes to .gitignore to ignore .DS_store files (a must for people working on macs) and previous dist directories. Not sure what you policy is on building dist for each commit, but I have done so, feel free to exclude if you normally only update dist for releases.
