### PR TITLE
fix getnetworkip in linux

### DIFF
--- a/lib/getnetworkip.js
+++ b/lib/getnetworkip.js
@@ -15,7 +15,7 @@ module.exports = (function () {
          break;
     default:
          command = 'ifconfig';
-         filterRE = /\binet\b[^:]+:\s*([^\s]+)/g;
+         filterRE = /\binet:\s*([^\s]+)/g;
          // filterRE = /\binet6[^:]+:\s*([^\s]+)/g; // IPv6
          break;
     }

--- a/lib/getnetworkip.js
+++ b/lib/getnetworkip.js
@@ -1,53 +1,92 @@
 module.exports = (function () {
     var ignoreRE = /^(127\.0\.0\.1|::1|fe80(:1)?::1(%.*)?)$/i;
 
-    var exec = require('child_process').exec;
-    var cached;    
-    var command;
-    var filterRE;
+    var cached;
+    var os=require('os');    
 
-    switch (process.platform) {
-    // TODO: implement for OSs without ifconfig command
-    case 'darwin':
-         command = 'ifconfig';
-         filterRE = /\binet\s+([^\s]+)/g;
-         // filterRE = /\binet6\s+([^\s]+)/g; // IPv6
-         break;
-    default:
-         command = 'ifconfig';
-         filterRE = /\binet:\s*([^\s]+)/g;
-         // filterRE = /\binet6[^:]+:\s*([^\s]+)/g; // IPv6
-         break;
-    }
+    if(os.networkInterfaces || os.getNetworkInterfaces){
+        //getNetworkInterfaces for node v0.5.x deprecated in v0.6.x
+        var networks = os.networkInterfaces? os.networkInterfaces() : os.getNetworkInterfaces();
 
-    return function (callback, bypassCache) {
-         // get cached value
-        if (cached && !bypassCache) {
-            callback(null, cached);
-            return;
-        }
-        // system call
-        exec(command, function (error, stdout, sterr) {
-            var ips = [];
-            // extract IPs
-            var matches = stdout.match(filterRE);
-            // JS has no lookbehind REs, so we need a trick
-            for (var i = 0; i < matches.length; i++) {
-                ips.push(matches[i].replace(filterRE, '$1'));
+        return function (callback, bypassCache){
+             // get cached value
+            if (cached && !bypassCache) {
+                callback(null, cached);
+                return;
             }
 
-            // filter BS
+            var ifaces=os.networkInterfaces();
+            var ips = [];
+            for (var dev in ifaces) {
+              ifaces[dev].forEach(function(details){
+                if (details.family=='IPv4') {
+                    ips.push(details.address);
+                }
+              });
+            }
+
+             // filter BS
             for (var i = 0, l = ips.length; i < l; i++) {
                 if (!ignoreRE.test(ips[i])) {
-                    //if (!error) {
-                        cached = ips[i];
-                    //}
-                    callback(error, ips[i]);
+                     cached = ips[i];
+                    callback(null, ips[i]);
                     return;
                 }
             }
             // nothing found
             callback(error, null);
-        });
-    };
+        };
+    }else{
+        //Deprecated, only for supporting node v0.4.x
+        var exec = require('child_process').exec;
+        var command;
+        var filterRE;
+
+        switch (process.platform) {
+        // TODO: implement for OSs without ifconfig command
+        case 'darwin':
+             command = 'ifconfig';
+             filterRE = /\binet\s+([^\s]+)/g;
+             // filterRE = /\binet6\s+([^\s]+)/g; // IPv6
+             break;
+        default:
+             command = 'ifconfig';
+             filterRE = /\binet:\s*([^\s]+)/g;
+             // filterRE = /\binet6[^:]+:\s*([^\s]+)/g; // IPv6
+             break;
+        }
+
+        return function (callback, bypassCache) {
+             // get cached value
+            if (cached && !bypassCache) {
+                callback(null, cached);
+                return;
+            }
+
+            
+            // system call
+            exec(command, function (error, stdout, sterr) {
+                var ips = [];
+                // extract IPs
+                var matches = stdout.match(filterRE);
+                // JS has no lookbehind REs, so we need a trick
+                for (var i = 0; i < matches.length; i++) {
+                    ips.push(matches[i].replace(filterRE, '$1'));
+                }
+
+                // filter BS
+                for (var i = 0, l = ips.length; i < l; i++) {
+                    if (!ignoreRE.test(ips[i])) {
+                        //if (!error) {
+                            cached = ips[i];
+                        //}
+                        callback(error, ips[i]);
+                        return;
+                    }
+                }
+                // nothing found
+                callback(error, null);
+            });
+        };
+    }
 })();


### PR DESCRIPTION
the correct regexp in linux

line 18 -
before:
filterRE = /\binet\b[^:]+:\s_([^\s]+)/g;
after:
filterRE = /\binet:\s_([^\s]+)/g;

Seems that the code is copy of http://stackoverflow.com/a/3742915 , and the author says:

" (tested on MacOS Snow Leopard only; hope it works on linux too) "

;)
